### PR TITLE
Exchanged internal links to publicly available ones

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,10 +2,10 @@
 
 Dieses Repository ist der Grundordner der Webseite [SwordCraftOnline.de](https://swordcraftonline.de)
 
-Alles was hier hochgeladen wird (und auf der Webseite angezeigt wird) steht unter der Verantwortung der Folgenden Contributoren und Developern des SwordCraftOnline Netzwerkes:
- - Leitender Developer [Hope (Aurel)](https://github.com/orgs/SwordCraftOnline-Netzwerk/people/Hopefuls)
+Alles was hier hochgeladen wird (und auf der Webseite angezeigt wird) steht unter der Verantwortung der folgenden Contributoren und Developern des SwordCraftOnline Netzwerkes:
+ - Leitender Developer [Hope (Aurel)](https://github.com/Hopefuls)
  - [MaesketYT](https://github.com/MaesketYT)
- - [Yasin](https://github.com/orgs/SwordCraftOnline-Netzwerk/people/yasinTheDeveloper)
+ - [Yasin](https://github.com/yasinTheDeveloper)
 
 
 Kontakt: 
@@ -13,6 +13,6 @@ Kontakt:
  - [Discord](https://discord.swordcraftonline.de)
 
 Notiz an Developer
- - Bei hinzufügen von Medien bitte den Content Delivery Server verwenden. Weiteres auf Anfrage bei Hope, er wird dieses genauer erklären
+ - Bei Hinzufügen von Medien bitte den Content Delivery Server verwenden. Weiteres auf Anfrage bei Hope, er wird dieses genauer erklären
  - Pull Requests bitte. Direkte Commits werden revertet.
  


### PR DESCRIPTION
This PR implements changes that can be divided into two categories.
I'll state those categories and the corresponding changes in a quick overview and try to motivate why those changes are necessary.

## Typo fixes
This PR includes some fixes of typos in the readme file.
While autocorrection and spelling software has become a given in our lives, the importance of spelling hasn’t lessened – it’s actually never been more important. As spelling and literacy have reached their apogee across all of human history, so too has the demands on the quality of delivery.
Tolerance for typos is low. On printed materials, it makes the producer look careless or cheap, while online it’s become a signal of a phishing or scamming attempt.
We don't want that for SwordCraftOnline! So I went ahead and fixed them in the readme file.

## Internal profile links
The profile links of the SCO developers linked to their internal profile page of this organization. This rendered people outside of the SCO organization unable to visit their profile pages. In an attempt to resolve this issue I changed the links to the public GitHub accounts.